### PR TITLE
eclipse-solargraph-plugin: Using a relative 'bash' command

### DIFF
--- a/eclipse-solargraph-plugin/src/main/java/io/github/pyvesb/eclipse_solargraph/utils/CommandHelper.java
+++ b/eclipse-solargraph-plugin/src/main/java/io/github/pyvesb/eclipse_solargraph/utils/CommandHelper.java
@@ -62,7 +62,8 @@ public class CommandHelper {
 	}
 
 	public static String[] getPlatformCommand(String command) {
-		return isWindows() ? new String[] { "cmd.exe", "/c", command } : new String[] { "/bin/bash", "-c", "-l", command };
+		// String tbd = System.get
+		return isWindows() ? new String[] { "cmd.exe", "/c", command } : new String[] { "bash", "-c", "-l", command };
 	}
 
 	public static boolean isWindows() {

--- a/eclipse-solargraph-plugin/src/main/java/io/github/pyvesb/eclipse_solargraph/utils/CommandHelper.java
+++ b/eclipse-solargraph-plugin/src/main/java/io/github/pyvesb/eclipse_solargraph/utils/CommandHelper.java
@@ -62,7 +62,6 @@ public class CommandHelper {
 	}
 
 	public static String[] getPlatformCommand(String command) {
-		// String tbd = System.get
 		return isWindows() ? new String[] { "cmd.exe", "/c", command } : new String[] { "bash", "-c", "-l", command };
 	}
 


### PR DESCRIPTION
On some hosts, the bash shell may not have been installed under `/bin`. 

On FreeBSD hosts for instance, bash may be installed from the [shells/bash](https://www.freshports.org/shells/bash) port at `/usr/local/bin/bash`, for a default prefix `/usr/local`. On NetBSD and generally under [pkgsrc](http://pkgsrc.org/), [bash](https://pkgsrc.se/shells/bash) may be available as `/usr/pkg/bin/bash` assuming a pkgsrc prefix `/usr/pkg`

This patch updates CommandHelper.getPlatformCommand(String) to use a relative pathname for the `bash` command. 

For running the provided shell command via the shell interpreter on non-Windows platforms, the appropriate `bash` command can then be resolved from the environment `PATH`

Tested under  _Run As -> Eclipse Application_ with Eclipse 2022-09 on FreeBSD 13.1 (openjdk18)