### PR TITLE
pom.xml: Using tycho version 2.7.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.5.0</version>
+    <version>2.7.0</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	</modules>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho.version>2.5.0</tycho.version>
+		<tycho.version>2.7.0</tycho.version>
 	</properties>
 	<build>
 		<plugins>


### PR DESCRIPTION
With tycho version 2.5.0 I was seeing bundle resolution errors when running `maven package`. This was with OpenJDK 11 from openSUSE Tumbleweed.

After updating to tycho 2.7.0 I was able to run `maven package` in the same OS environment. This produced a plugin *.jar file in `eclipse-solargraph-plugin/target/`. This file can then be installed by copying the file to a suitable plugins directory for the Eclipse installation. The location of that directory may vary per whether the Eclipse installation is user-writable. If it is user-writable, the `plugins` dir under the Eclipse installation may work. If not, there may be a `plugins` dir under an installation-specific subdir or `~/.eclipse/`. 

This has been tested for building a *.jar under OpenJDK 11 on openSUSE. The plugin was then tested in an Eclipse installation on FreeBSD, using OpenJDK 18. After installing the  solargraph and readapt gems then configuring the paths for these in the plugin preferences, it's usable on FreeBSD, with the patch from the earlier pull request for using a relative bash pathname.

This patch updates the tycho version to 2.7.0. The [latest stable version](https://mvnrepository.com/artifact/org.eclipse.tycho/tycho-maven-plugin) is 3.0.0 at present, it might work too
